### PR TITLE
Adjust workspace scroll behaviour

### DIFF
--- a/src/components/ChatPanel.js
+++ b/src/components/ChatPanel.js
@@ -93,22 +93,6 @@ export default function ChatPanel({ conversation, messages, onSendMessage }) {
 
   return (
     <section className="chat-panel" aria-label={`Conversation ${conversation.name}`}>
-      <header className="chat-panel__header">
-        <div>
-          <h1 className="chat-panel__title">{conversation.name}</h1>
-          <p className="chat-panel__subtitle">{conversation.description}</p>
-        </div>
-        <dl className="chat-panel__stats">
-          <div>
-            <dt>Members</dt>
-            <dd>{conversation.members}</dd>
-          </div>
-          <div>
-            <dt>Topic</dt>
-            <dd>{conversation.topic}</dd>
-          </div>
-        </dl>
-      </header>
       <div className="chat-panel__messages" ref={scrollRef}>
         {groupedMessages.map((group) =>
           group.type === 'day' ? (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -73,9 +73,11 @@ textarea {
 
 .page {
   min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   background: var(--color-bg-page);
+  overflow: hidden;
 }
 
 .top-nav {
@@ -203,11 +205,13 @@ textarea {
 .workspace {
   flex: 1;
   min-height: 0;
+  height: 100%;
   display: grid;
   grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
   background: linear-gradient(135deg, rgba(99, 102, 241, 0.12), rgba(6, 182, 212, 0.08));
   gap: 1px;
   position: relative;
+  overflow: hidden;
 }
 
 .workspace--collapsed {
@@ -220,6 +224,8 @@ textarea {
   flex-direction: column;
   gap: 1.75rem;
   padding: 1.5rem;
+  height: 100%;
+  min-height: 0;
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--color-accent) transparent;
@@ -352,50 +358,9 @@ textarea {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  height: 100%;
   border-left: 1px solid var(--color-border);
-}
-
-.chat-panel__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 2rem;
-  padding: 1.75rem 2.5rem 1.25rem;
-  border-bottom: 1px solid var(--color-border);
-  backdrop-filter: blur(10px);
-}
-
-.chat-panel__title {
-  margin: 0;
-  font-size: 1.5rem;
-  font-weight: 600;
-  color: var(--color-text-primary);
-}
-
-.chat-panel__subtitle {
-  margin: 0.45rem 0 0;
-  color: var(--color-text-secondary);
-  max-width: 40ch;
-}
-
-.chat-panel__stats {
-  display: grid;
-  grid-template-columns: repeat(2, auto);
-  gap: 1.5rem;
-  margin: 0;
-}
-
-.chat-panel__stats dt {
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-text-tertiary);
-}
-
-.chat-panel__stats dd {
-  margin: 0.25rem 0 0;
-  font-weight: 600;
-  color: var(--color-text-primary);
+  overflow: hidden;
 }
 
 .chat-panel__messages {
@@ -615,16 +580,12 @@ textarea {
     box-shadow: var(--shadow-floating);
     border: 1px solid var(--color-border);
     z-index: 20;
+    height: auto;
+    max-height: calc(100% - 2.5rem);
   }
 
   .workspace--collapsed > .sidebar {
     display: none;
-  }
-
-  .chat-panel__header {
-    flex-direction: column;
-    gap: 1rem;
-    padding: 1.25rem 1.5rem;
   }
 
   .chat-panel__messages {
@@ -649,6 +610,7 @@ textarea {
   .workspace > .sidebar {
     width: calc(100% - 1.5rem);
     margin: 0.75rem;
+    max-height: calc(100% - 1.5rem);
   }
 
   .message {
@@ -661,8 +623,4 @@ textarea {
     height: 36px;
   }
 
-  .chat-panel__stats {
-    grid-template-columns: 1fr;
-    gap: 0.75rem;
   }
-}


### PR DESCRIPTION
## Summary
- remove the chat header section so the panel focuses on the message feed and composer
- constrain the workspace layout to the viewport so the sidebar and chat messages scroll independently
- update responsive sidebar sizing so the overlay version keeps its own scroll area

## Testing
- npm run lint *(fails: `next` binary missing because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc0a0fd108330a19cbb61cce68e92